### PR TITLE
IM_Assert fix (Reach::RenderMenu)

### DIFF
--- a/fusion/src/base/moduleManager/modules/combat/reach.cpp
+++ b/fusion/src/base/moduleManager/modules/combat/reach.cpp
@@ -119,17 +119,17 @@ void Reach::RenderMenu()
 	ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.12f, 0.12f, 0.12f, 0.5));
 	ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10);
 
-	if (ImGui::BeginChild("reach", ImVec2(425, 75))) {
+	ImGui::BeginChild("reach", ImVec2(425, 75));
 
-		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 3);
-		Menu::DoToggleButtonStuff(230044, "Toggle Reach", &Reach::Enabled);
+	ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 3);
+	Menu::DoToggleButtonStuff(230044, "Toggle Reach", &Reach::Enabled);
 
-		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
-		ImGui::Separator();
-		Menu::DoSliderStuff(560117, "Reach Distance", &Reach::ReachDistance, 0, 4);
+	ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
+	ImGui::Separator();
+	Menu::DoSliderStuff(560117, "Reach Distance", &Reach::ReachDistance, 0, 4);
 
-		ImGui::EndChild();
-	}
+	ImGui::EndChild();
+	
 	ImGui::PopStyleVar();
 	ImGui::PopStyleColor();
 


### PR DESCRIPTION
An IM_ASSERT was caused for me every time I opened the combat menu because of the reach function.

I'm not sure why BeginChild was in an if statement, I've personally never seen that before but removing it also fixes the assert.
But I'm not really the best at ImGui so there may be something I'm not considering.