### PR TITLE
Fixed menu breaking when changing fullscreen states properly.

### DIFF
--- a/fusion/src/base/base.cpp
+++ b/fusion/src/base/base.cpp
@@ -37,16 +37,8 @@ void Base::Init()
 
 	Base::Running = true;
 
-	SDK::Minecraft->gameSettings->SetFullscreenKeyToNull();
 	while (Base::Running)
 	{
-		if (IsKeyReleased(VK_F11)) {
-			if (Borderless::Enabled)
-				Borderless::Restore(Menu::HandleWindow);
-			else
-				Borderless::Enable(Menu::HandleWindow);
-		}
-
 		ModuleManager::UpdateModules();
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 	}
@@ -57,7 +49,6 @@ void Base::Init()
 void Base::Kill()
 {
 	Patcher::Kill();
-	SDK::Minecraft->gameSettings->RestoreFullscreenKey();
 	if (Borderless::Enabled)
 		Borderless::Restore(Menu::HandleWindow);
 


### PR DESCRIPTION
Removed the borderless implementation.

Window handle changed on fullscreen state changes.

So you have to shutdown the imgui opengl and win32 implementation, then reinitialize it.

After, rehook wndproc so itll attach to the new window handle.